### PR TITLE
handling filter except published and draft

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventController.php
+++ b/app/Http/Controllers/Rdt/RdtEventController.php
@@ -51,7 +51,7 @@ class RdtEventController extends Controller
             });
         }
 
-        if ($status=='draft' || $status=='published') {
+        if ($status == 'draft' || $status == 'published') {
             if ($status === 'draft') {
                 $statusEnum = RdtEventStatus::DRAFT();
             }

--- a/app/Http/Controllers/Rdt/RdtEventController.php
+++ b/app/Http/Controllers/Rdt/RdtEventController.php
@@ -26,23 +26,13 @@ class RdtEventController extends Controller
         $perPage   = $request->input('per_page', 15);
         $sortBy    = $request->input('sort_by', 'created_at');
         $sortOrder = $request->input('sort_order', 'desc');
-        $status    = $request->input('status', 'draft');
+        $status    = $request->input('status', 'semua');
         $search    = $request->input('search');
 
         $perPage = $this->getPaginationSize($perPage);
 
         if (in_array($sortBy, ['id', 'event_name', 'start_at', 'end_at', 'status', 'created_at']) === false) {
             $sortBy = 'event_name';
-        }
-
-        $statusEnum = 'draft';
-
-        if ($status === 'draft') {
-            $statusEnum = RdtEventStatus::DRAFT();
-        }
-
-        if ($status === 'published') {
-            $statusEnum = RdtEventStatus::PUBLISHED();
         }
 
         $records = RdtEvent::query();
@@ -61,7 +51,17 @@ class RdtEventController extends Controller
             });
         }
 
-        $records->whereEnum('status', $statusEnum);
+        if ($status=='draft' || $status=='published') {
+            if ($status === 'draft') {
+                $statusEnum = RdtEventStatus::DRAFT();
+            }
+    
+            if ($status === 'published') {
+                $statusEnum = RdtEventStatus::PUBLISHED();
+            }
+            $records->whereEnum('status', $statusEnum);
+        }
+
         $records->orderBy($sortBy, $sortOrder);
         $records->with(['city']);
         $records->withCount(['invitations', 'schedules']);

--- a/app/Http/Controllers/Rdt/RdtEventController.php
+++ b/app/Http/Controllers/Rdt/RdtEventController.php
@@ -26,7 +26,7 @@ class RdtEventController extends Controller
         $perPage   = $request->input('per_page', 15);
         $sortBy    = $request->input('sort_by', 'created_at');
         $sortOrder = $request->input('sort_order', 'desc');
-        $status    = $request->input('status', 'semua');
+        $status    = $request->input('status', 'all');
         $search    = $request->input('search');
 
         $perPage = $this->getPaginationSize($perPage);

--- a/app/Http/Controllers/Rdt/RdtEventController.php
+++ b/app/Http/Controllers/Rdt/RdtEventController.php
@@ -51,15 +51,12 @@ class RdtEventController extends Controller
             });
         }
 
-        if ($status == 'draft' || $status == 'published') {
-            if ($status === 'draft') {
-                $statusEnum = RdtEventStatus::DRAFT();
-            }
+        if ($status === 'draft') {
+            $records->whereEnum('status', RdtEventStatus::DRAFT());
+        }
     
-            if ($status === 'published') {
-                $statusEnum = RdtEventStatus::PUBLISHED();
-            }
-            $records->whereEnum('status', $statusEnum);
+        if ($status === 'published') {
+            $records->whereEnum('status', RdtEventStatus::PUBLISHED());
         }
 
         $records->orderBy($sortBy, $sortOrder);


### PR DESCRIPTION
### Overview
Sebelumnya jika dipilih filter semua pada halaman kegiatan maka sistem akan memunculkan list event yang status nya draft, karna by default ketika halaman kegiatan di akses tidak mengirimkan parameter status. 

PR ini menghadle masalah ini, jadi filter status hanya akan di eksekusi kalau parameter status berisi value draft atau publised, selain itu akan mereturn semua event.

CC : @yohang88 

### Related Task : 
https://trello.com/c/v7WBtdde/101-kegiatan-bug-filter-status