### PR TITLE
fix typo class OccupationType name

### DIFF
--- a/app/Entities/RdtApplicant.php
+++ b/app/Entities/RdtApplicant.php
@@ -91,7 +91,7 @@ class RdtApplicant extends Model
 
     public function occupation()
     {
-        return $this->belongsTo(occupationType::class, 'occupation_type', 'occupation_type_value');
+        return $this->belongsTo(OccupationType::class, 'occupation_type', 'occupation_type_value');
     }
 
     public function invitations()


### PR DESCRIPTION
### Overview
perbaikan masalah error Class 'App\Entities\occupationType' not found yang disebabkan kesalahan penulisan nama class.

### Related Issue : 
https://sentry.digitalservice.id/organizations/jabardigitalservice/issues/1412/?project=11&query=is%3Aunresolved

cc : @yohang88 