### PR TITLE
Fix cors saat export list peserta dengan format F1

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -46,7 +46,7 @@ return [
     /*
      * Sets the Access-Control-Expose-Headers response header with these headers.
      */
-    'exposed_headers' => [],
+    'exposed_headers' => ['Content-Disposition'],
 
     /*
      * Sets the Access-Control-Max-Age response header when > 0.


### PR DESCRIPTION
Dugaan root cause penyebab error/gagal saat export format F1:

1. Sebelum ini sebenarnya sudah menggunakan middleware `Fruitcake\Cors\HandleCors` untuk handling CORS (`config/cors.php`), sehingga tidak perlu ditambahkan manual. Jadi beberapa baris `header()` yang ditambahkan manual di controller, bisa dihapus.

2. Problemnya adalah saat Export dengan menggunakan method `openToBrowser`, ternyata library `box/spout` melakukan override response headers terlebih dulu, sehingga headers yang diset oleh middleware `Fruitcake\Cors\HandleCors` jadi tidak terpakai. Sehingga muncul issue CORS.

3. Jadi perbaikannya dengan mengubah export dengan method `openToFile`, namun tidak write ke sebuah file tapi ke PHP stream `php://stdout`. Lalu di controller tersebut mengembalikan `response` berupa `stream`, dengan beberapa header yang kita override sendiri. Dengan cara ini, middleware `Fruitcake\Cors\HandleCors` bisa bekerja dengan benar, menambahkan atribut CORS.

4. Issue berikutnya, ternyata `config/cors.php` harus disesuaikan bagian `exposed_headers`, dengan menambahkan `Content-Disposition`. Jika tidak ada atribut ini, si javascript client tidak bisa membaca header response tersebut.