### PR TITLE
fix bug waktu pengiriman notifikasi hasil test yang tidak muncul di backoffice

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventNotifyTestResultController.php
+++ b/app/Http/Controllers/Rdt/RdtEventNotifyTestResultController.php
@@ -36,6 +36,7 @@ class RdtEventNotifyTestResultController extends Controller
     {
         $invitation->applicant->notify(new TestResult());
         $invitation->notified_result_at = Carbon::now();
+        $invitation->save();
 
         Log::info('NOTIFY_TEST_RESULT', [
             'applicant'  => $invitation->applicant,


### PR DESCRIPTION
### Overview
Perbaikan bug ketika mengirimkan notifikasi tapi waktu notifikasi tidak tecatat di database.

### Related Taks : 
https://trello.com/c/heyfSUDb/130-bug-history-ketika-kirim-hasil

cc : @yohang88 