### PR TITLE
rewording not_all dan unknown menjadi tanpa keriteria

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventParticipantListExportF1Controller.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantListExportF1Controller.php
@@ -109,8 +109,8 @@ class RdtEventParticipantListExportF1Controller extends Controller
             'SUSPECT' => 'Kasus Suspek',
             'PROBABLE' => 'Kasus Probable',
             'CLOSE_CONTACT' => 'Kontak Erat',
-            'NOT_ALL' => 'Bukan Semuanya',
-            'UNKNOWN' => 'Tidak Tahu',
+            'NOT_ALL' => 'Tanpa Kriteria',
+            'UNKNOWN' => 'Tanpa Kriteria',
             'ODP' => 'Orang Dalam pengawasan',
             'OTG' => 'Orang Tanpa Gejala',
             'PDP' => 'Pasien Dalam Pengawasan'


### PR DESCRIPTION
### Overview
penyesuaian value status kesehatan dengan labkes, di labkes tidak ada value status kesehatan not_all dan unknow.
untuk selain jenis status kesehatan yang sudah umum labkes menggunakan value Tanpa Kriteria.
jadi PR ini untuk mengakomodir penyesuaian tersebut.

Related Task :
https://trello.com/c/4Zd6mn2w/141-perubahan-pertanyaan-di-microste

cc : @yohang88 