### PR TITLE
menambahkan filter peserta yang sudah dihapus pada list peserta event

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
@@ -30,6 +30,7 @@ class RdtEventParticipantListController extends Controller
         $records->join('rdt_applicants', 'rdt_invitations.rdt_applicant_id', '=', 'rdt_applicants.id');
 
         $records->where('rdt_invitations.rdt_event_id', $rdtEvent->id);
+        $records->whereNull('rdt_applicants.deleted_at');
 
         if ($search) {
             $records->where(function ($query) use ($search) {
@@ -60,7 +61,6 @@ class RdtEventParticipantListController extends Controller
         if (in_array($perPage, $perPageAllowed)) {
             return $perPage;
         }
-        
         return 15;
     }
 }


### PR DESCRIPTION
### overview
peserta yang sudah di delete dari data master peserta akan muncul sebagai null di list peserta event, PR ini menambahkan filter untuk tidak menampilkan data peserta event yang sudah di hapus.

### Related task :
https://trello.com/c/2x0eS9zj/151-hapus-peserta-ketika-peserta-dihapus-maka-peserta-tersebut-akan-otomatis-terhapus-dari-kegiatan-yang-terdaftar