### PR TITLE
Reset invitation attedance and sample code

### DIFF
--- a/app/Http/Controllers/Rdt/RdtInvitationResetController.php
+++ b/app/Http/Controllers/Rdt/RdtInvitationResetController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Rdt;
+
+use App\Http\Controllers\Controller;
+use App\Entities\RdtInvitation;
+
+class RdtInvitationResetController extends Controller
+{
+    public function __invoke($id)
+    {
+        $rdtInvitation  = RdtInvitation::findOrFail($id);
+        $rdtInvitation->update(['lab_code_sample' =>null ,'attended_at' => null,'attend_location' => null]);
+        return response()->json(['message' => 'OK']);
+    }
+}

--- a/app/Http/Controllers/Rdt/RdtInvitationResetController.php
+++ b/app/Http/Controllers/Rdt/RdtInvitationResetController.php
@@ -10,7 +10,7 @@ class RdtInvitationResetController extends Controller
     public function __invoke($id)
     {
         $rdtInvitation  = RdtInvitation::findOrFail($id);
-        $rdtInvitation->update(['lab_code_sample' =>null ,'attended_at' => null,'attend_location' => null]);
+        $rdtInvitation->update(['lab_code_sample' => null ,'attended_at' => null,'attend_location' => null]);
         return response()->json(['message' => 'OK']);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,6 +63,7 @@ Route::group(['middleware' => 'auth:api'], function () {
         ->middleware('can:view,rdtEvent');
     Route::get('rdt/invitation/{id}', 'Rdt\RdtEventParticipantDetailController');
     Route::put('rdt/invitation/{id}', 'Rdt\RdtInvitationLabResultUpdateController');
+    Route::put('rdt/invitation/{id}/reset', 'Rdt\RdtInvitationResetController');
 
     Route::post('rdt/events/{rdtEvent}/participants', 'Rdt\RdtEventParticipantAddController');
     Route::post('rdt/events/{rdtEvent}/participants-remove', 'Rdt\RdtEventParticipantRemoveController');


### PR DESCRIPTION
### Overview
endpoint untuk melakukan reset data kode sampel, lokasi hadir dan waktu hadir dari tabel invitation.
use casenya untuk melakukan reset data yang dilakukan oleh user untuk melakukan testing apakah aplikasi bejalan dengan baik atau tidak, atau jika peserta sudah daftar tapi melarikan diri sehingga data nya perlu di reset.

### Related Task
https://trello.com/c/hbP88FCT/159-detail-kegiatan-admin-bisa-menguncheck-peserta-yang-sudah-check-in-tapi-tidak-mengikuti-tes

cc : @yohang88 