### PR TITLE
stop if apllicant not invited

### DIFF
--- a/app/Http/Controllers/Rdt/RdtCheckinController.php
+++ b/app/Http/Controllers/Rdt/RdtCheckinController.php
@@ -51,23 +51,7 @@ class RdtCheckinController extends Controller
         if ($invitation === null) {
             $applicant = RdtApplicant::where('registration_code', $registrationCode)->firstOrFail();
 
-            $invitation = new RdtInvitation();
-            $invitation->applicant()->associate($applicant);
-            $invitation->event()->associate($event);
-            $invitation->save();
-
-            if ($applicant->pikobar_session_id === null) {
-                $applicant->pikobar_session_id = $event->event_code;
-            }
-
-            $applicant->status = RdtApplicantStatus::APPROVED();
-            $applicant->save();
-
-            Log::info('APPLICANT_EVENT_CHECKIN_NOT_INVITED', [
-                'event_code' => $eventCode,
-                'applicant'  => $applicant,
-                'invitation' => $invitation,
-            ]);
+            $this->responseApplicantEventCheckinNotInvited($eventCode, $applicant, $invitation);
         }
 
         if ($invitation->attended_at !== null) {
@@ -151,6 +135,21 @@ class RdtCheckinController extends Controller
         return response()->json([
             'error'   => 'ALREADY_USED_LAB_CODE_SAMPLE',
             'message' => 'Kode Sampel Lab sudah digunakan untuk checkin pada event ini.',
+        ], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+
+    protected function responseApplicantEventCheckinNotInvited($eventCode, $applicant, $invitation)
+    {
+        Log::info('APPLICANT_EVENT_CHECKIN_NOT_INVITED', [
+            'event_code' => $eventCode,
+            'applicant'  => $applicant,
+            'invitation' => $invitation,
+        ]);
+
+        return response()->json([
+            'error'   => 'APPLICANT_NOT_INVITED_AT_THIS_EVENT',
+            'message' => 'peserta tidak terdaftar pada event ini.',
         ], Response::HTTP_UNPROCESSABLE_ENTITY);
     }
 }

--- a/app/Http/Controllers/Rdt/RdtCheckinController.php
+++ b/app/Http/Controllers/Rdt/RdtCheckinController.php
@@ -50,8 +50,7 @@ class RdtCheckinController extends Controller
 
         if ($invitation === null) {
             $applicant = RdtApplicant::where('registration_code', $registrationCode)->firstOrFail();
-
-            $this->responseApplicantEventCheckinNotInvited($eventCode, $applicant, $invitation);
+            return $this->responseApplicantEventCheckinNotInvited($eventCode, $applicant, $invitation);
         }
 
         if ($invitation->attended_at !== null) {

--- a/tests/Feature/RdtCheckinTest.php
+++ b/tests/Feature/RdtCheckinTest.php
@@ -108,18 +108,9 @@ class RdtCheckinTest extends TestCase
             'lab_code_sample'   => 'L0001',
             'location'          => 'PUSKESMAS CIPEDES',
         ])
-            ->assertSuccessful()
-            ->assertJsonStructure(['data' => ['registration_code', 'name', 'status']])
-            ->assertJsonFragment([
-                'registration_code' => $rdtApplicant->registration_code,
-                'name'              => $rdtApplicant->name,
-            ]);
-
-        $this->assertDatabaseHas('rdt_invitations', [
-            'rdt_event_id'      => $rdtEvent->id,
-            'registration_code' => $rdtApplicant->registration_code,
-            'lab_code_sample'   => 'L0001',
-            'attend_location'   => 'PUSKESMAS CIPEDES',
+        ->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonFragment([
+            'error' => 'APPLICANT_NOT_INVITED_AT_THIS_EVENT',
         ]);
     }
 


### PR DESCRIPTION
### overview
aplikasi checkin sekarang memungkinkan user untuk melihat daftar event lebih dari satu ketika dia login dan beberapa waktu lalu kejadian ada user yang salah melakukan checkin peserta bukan pada event seharusnya sehingga menyebabkan list peserta yang tercheckin bukan pada event yang mereka ikutin.

PR ini untuk melakukan handling agar peserta yang tidak terdaftar pada event tidak bisa checkin.

### Related Task :
https://trello.com/c/Dn3bzFZa/169-peserta-tidak-bisa-check-in-di-kegiatan-yang-tidak-terdaftar

cc : @yohang88 

