### PR TITLE
perbaikan response event_ent_at setelah register

### DIFF
--- a/app/Http/Controllers/Rdt/RdtRegisterController.php
+++ b/app/Http/Controllers/Rdt/RdtRegisterController.php
@@ -44,7 +44,7 @@ class RdtRegisterController extends Controller
             'status'            => $applicant->status,
             'registration_code' => $applicant->registration_code,
             'event_start_at'    => $event->start_at,
-            'event_end_at'      => $event->start_at,
+            'event_end_at'      => $event->end_at,
             'event_location'    => $event->event_location,
             'qr_code'           => $applicant->QrCodeUrl,
             'download_url'      => UrlSigner::sign($url),


### PR DESCRIPTION
### overview
perbaikan salah penulisan nama field pada response key event_end_at, seharusnya pada response event_end_at pakai field end_at bukan start_at.

CC : @yohang88 