### PR TITLE
add event start from schedule

### DIFF
--- a/app/Http/Controllers/Rdt/RdtRegisterController.php
+++ b/app/Http/Controllers/Rdt/RdtRegisterController.php
@@ -36,15 +36,11 @@ class RdtRegisterController extends Controller
    
         event(new ApplicantRegistered($applicant));
 
-        if ($event) {
-            $applicantEventSchedule = RdtInvitation::select('rdt_event_schedules.*')
+        $applicantEventSchedule = RdtInvitation::select('rdt_event_schedules.*')
                                         ->leftJoin('rdt_event_schedules', 'rdt_invitations.rdt_event_schedule_id', 'rdt_event_schedules.id')
                                         ->where('rdt_invitations.rdt_applicant_id', $applicant->id)
-                                        ->where('rdt_invitations.rdt_event_id', $event->id)
+                                        ->where('rdt_invitations.rdt_event_id', optional($event)->id)
                                         ->first();
-        } else {
-            $applicantEventSchedule = null;
-        }
 
         $url = URL::route(
             'registration.download',

--- a/app/Http/Controllers/Rdt/RdtRegisterController.php
+++ b/app/Http/Controllers/Rdt/RdtRegisterController.php
@@ -32,6 +32,7 @@ class RdtRegisterController extends Controller
         $applicant->save();
 
         $event = RdtEvent::where('event_code', $request->pikobar_session_id)->first();
+        $schedule = $event != null ? $event->schedules->first() : null;
 
         event(new ApplicantRegistered($applicant));
 
@@ -43,8 +44,8 @@ class RdtRegisterController extends Controller
             'name'              => $applicant->name,
             'status'            => $applicant->status,
             'registration_code' => $applicant->registration_code,
-            'event_start_at'    => optional($event)->start_at,
-            'event_end_at'      => optional($event)->end_at,
+            'event_start_at'    => optional($schedule)->start_at,
+            'event_end_at'      => optional($schedule)->end_at,
             'event_location'    => optional($event)->event_location,
             'qr_code'           => $applicant->QrCodeUrl,
             'download_url'      => UrlSigner::sign($url),

--- a/app/Listeners/Rdt/InviteToEventByCode.php
+++ b/app/Listeners/Rdt/InviteToEventByCode.php
@@ -87,6 +87,7 @@ class InviteToEventByCode
 
         $invitation->event()->associate($rdtEvent);
         $invitation->applicant()->associate($applicant);
+        $invitation->rdt_event_schedule_id = 1;
         $invitation->save();
 
         $applicant->status = RdtApplicantStatus::APPROVED();

--- a/app/Listeners/Rdt/InviteToEventByCode.php
+++ b/app/Listeners/Rdt/InviteToEventByCode.php
@@ -87,7 +87,11 @@ class InviteToEventByCode
 
         $invitation->event()->associate($rdtEvent);
         $invitation->applicant()->associate($applicant);
-        $invitation->rdt_event_schedule_id = 1;
+        if ($applicant->pikobar_session_id != null) {
+            $firstEventSchedule = $rdtEvent->schedules()->first();
+            $invitation->rdt_event_schedule_id = $firstEventSchedule->id;
+        }
+        
         $invitation->save();
 
         $applicant->status = RdtApplicantStatus::APPROVED();


### PR DESCRIPTION
### Overview
sekarang informasi yang muncul setelah daftar adalah tanggal awal dan berakhir event, sedangkan kondisi yang diharapkan sekarang adalah yang muncul tanggal awal dan berakhir kloter dimana peserta tersebut di invite.

PR ini melakukan sedikit perubahan info mulai dan berakhir event menjadi bersumber dari kloter ( jika peserta melakukan pendaftaran menggunakan session id ).

untuk sekarang seluruh pendaftar yang daftar melalui aplikasi langsung masuk ke kloter 1 ( secara default ).

### Related Task
https://trello.com/c/Yy6VooD2/179-peserta-langsung-mendapatkan-kloter-undangan-ketika-mendaftar-dr-link-pendaftaran-supaya-dia-tahu-kapan-dia-bisa-datang-buat-tes

CC : @yohang88 