### PR TITLE
remove condition save pikobar_session_id

### DIFF
--- a/app/Listeners/Rdt/InviteToEventByCode.php
+++ b/app/Listeners/Rdt/InviteToEventByCode.php
@@ -56,9 +56,6 @@ class InviteToEventByCode
         $rdtEvent = RdtEvent::where('event_code', $applicant->pikobar_session_id)->first();
 
         if ($rdtEvent === null) {
-            $applicant->pikobar_session_id = null;
-            $applicant->save();
-
             Log::info('APPLICANT_REGISTER_INVITE_TO_EVENT_NOTFOUND', [
                 'applicant' => $applicant->toArray(),
             ]);


### PR DESCRIPTION
### overview
kondisi sekarang, pikobar_session_id hanya disimpan jika pikobar_session_id = kode_event, selain itu data pikobar_session_id akan jadi null ketika applicant_register.

sekarang ada kebutuhan untuk skenario seperti ini.
admin A membuat event  B dengan durasi 1 hari dan 2 kloter, lalu ketika pendaftaran admin akan memberikan link undangan dengan melakukan modifikasi pikobar_session_id menjadi :
kode_event_B1 untuk calon peserta event B kloter 1 ( http://localhost:52053/#/?sessionId=KODE_EVENT_B1 )
kode_event_B2 untuk calon peserta event B kloter 2 ( http://localhost:52053/#/?sessionId=KODE_EVENT_B2 )

ketika calon peserta melakukan pendaftaran melalui link di atas, peserta tidak langsung di invite ke dalam event.
sehingga admin harus melakukan invite peserta dengan mencari peserta dengan mengetikkan kode_event_B1 dan nanti peserta yang muncul akan di invite ( fitur pencarian berdasarkan pikobar_session_id ini udah ready )

cc : @yohang88 
