### PR TITLE
set pikobar_session_id to null after invite to event

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventParticipantAddController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantAddController.php
@@ -36,6 +36,7 @@ class RdtEventParticipantAddController extends Controller
 
             // Jika status peserta masih NEW, ubah jadi APPROVED
             $applicant->status = RdtApplicantStatus::APPROVED();
+            $applicant->pikobar_session_id = null;
             $applicant->save();
 
             // Cek existing undangan/invitation.


### PR DESCRIPTION
### Overview
kondisi sekarang, pikobar session id tidak berubah walaupun udah di invite ke event, sehingga ketika admin ingin melakukan invite peserta lagi dengan melakukan pencarian pikobar_session_id maka data peserta tersebut masih muncul. seharusya tidak muncul lagi.

PR ini bertujuan untuk memberikan value null pada pikobar_session_id setelah peserta di invite ke event.

### Related Task
https://trello.com/c/pVRsb87l/190-session-id-terupdate-ketika-peserta-dimasukan-ke-dalam-kegiatan-baru