### PR TITLE
add event_code to pikobar_session_id

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventParticipantAddController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantAddController.php
@@ -36,7 +36,7 @@ class RdtEventParticipantAddController extends Controller
 
             // Jika status peserta masih NEW, ubah jadi APPROVED
             $applicant->status = RdtApplicantStatus::APPROVED();
-            $applicant->pikobar_session_id = null;
+            $applicant->pikobar_session_id = $rdtEvent->event_code;
             $applicant->save();
 
             // Cek existing undangan/invitation.

--- a/app/Http/Controllers/Rdt/RdtEventParticipantListExportF1Controller.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantListExportF1Controller.php
@@ -142,6 +142,9 @@ class RdtEventParticipantListExportF1Controller extends Controller
             $attendedAt = Carbon::parse($row->attended_at)
                             ->timezone(config('app.timezone_frontend'))
                             ->format('Y-m-d');
+
+            $eventStartAt = Carbon::parse($rdtEvent->start_at)->format('dmY');
+            
             $row =  [
                         $row->number,
                         $row->lab_code_sample ,
@@ -149,7 +152,7 @@ class RdtEventParticipantListExportF1Controller extends Controller
                         $row->host_name,
                         '',
                         '',
-                        $rdtEvent->event_name . ' ' . Carbon::parse($row->attended_at)->format('dmY'),
+                        $rdtEvent->event_name . ' ' . $eventStartAt,
                         $personStatusValue[$row->person_status] ?? null,
                         $row->name,
                         $row->nik,


### PR DESCRIPTION
### Overview
update pikobar_seeion_id menjadi event_code ketika di invite dalam event.
perbaikan category menjadi nama event tanggal mulai ( ex : event ABC 23122020 ).
note : yang perbaikan category kemarin saya salah paham, ternyata maksudnya tanggal event bukan tanggal checkin.

### Related Task
https://trello.com/c/mSoG4CTJ/196-daftar-peserta-bug-search-by-session-id

cc : @yohang88 