### PR TITLE
remove double semicolon on route dev :D

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\URL;
 
 Route::get('/', 'HomeController');
 
-Route::post('synctolabkes/{rdtEvent}', 'SyncToLabkesController')->middleware('api');;
+Route::post('synctolabkes/{rdtEvent}', 'SyncToLabkesController')->middleware('api');
 // RDT Registration
 Route::post('rdt/register', 'Rdt\RdtRegisterController');
 Route::get('rdt/check-event', 'Rdt\RdtCheckEventController');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32012588/106731768-7d3daa00-6642-11eb-8f18-e33054d4e309.png)

Note:
- Terdapat double semicolon on routing develop :smile:  (ini yg menyebabkan case klik button 'Kirim Data' diatas menjadi error 500)

cc : mas @yohang88 