### PR TITLE
add-checkin-when-update-kode-sample

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventParticipantSetLabCodeController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantSetLabCodeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Rdt;
 
 use App\Entities\RdtInvitation;
 use App\Http\Controllers\Controller;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 
 class RdtEventParticipantSetLabCodeController extends Controller
@@ -21,6 +22,8 @@ class RdtEventParticipantSetLabCodeController extends Controller
          */
         $rdtInvitation                  = RdtInvitation::findOrFail($request->input('rdt_invitation_id'));
         $rdtInvitation->lab_code_sample = $request->input('lab_code_sample');
+        $rdtInvitation->attended_at == null ? $rdtInvitation->attended_at = Carbon::now() : $rdtInvitation->attended_at;
+        $rdtInvitation->attend_location == null ? $rdtInvitation->attend_location = $rdtInvitation->event->event_location : $rdtInvitation->attend_location;
         $rdtInvitation->save();
 
         return response()->json(['status' => 'OK']);

--- a/app/Http/Controllers/Rdt/RdtEventParticipantSetLabCodeController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantSetLabCodeController.php
@@ -22,8 +22,12 @@ class RdtEventParticipantSetLabCodeController extends Controller
          */
         $rdtInvitation                  = RdtInvitation::findOrFail($request->input('rdt_invitation_id'));
         $rdtInvitation->lab_code_sample = $request->input('lab_code_sample');
-        $rdtInvitation->attended_at == null ? $rdtInvitation->attended_at = Carbon::now() : $rdtInvitation->attended_at;
-        $rdtInvitation->attend_location == null ? $rdtInvitation->attend_location = $rdtInvitation->event->event_location : $rdtInvitation->attend_location;
+        if ($rdtInvitation->attended_at === null) {
+            $rdtInvitation->attended_at = Carbon::now();
+        }
+        if ($rdtInvitation->attend_location === null) {
+            $rdtInvitation->attend_location = $rdtInvitation->event->event_location;
+        }
         $rdtInvitation->save();
 
         return response()->json(['status' => 'OK']);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32012588/107479392-a1067000-6bad-11eb-94b4-db324cc07c50.png)

Overview:
- Update endpoint untuk dapat checkin ketika me 'insert' kode sample
- JIka peserta belum checkin maka otomatis akan checkin ketika kode sampel tersedia
- Jika peserta sudah checkin maka waktu dan lokasi checkin tidak berubah

Note:
- Tested

cc: mas @yohang88 @jabardigitalservice/jds-backend 