### PR TITLE
add field status on simlab to received status integrasi peserta

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
@@ -18,17 +18,16 @@ class RdtEventParticipantListController extends Controller
      */
     public function __invoke(Request $request, RdtEvent $rdtEvent)
     {
-        $perPage   = $request->input('per_page', 15);
-        $sortBy    = $request->input('sort_by', 'created_at');
+        $perPage = $request->input('per_page', 15);
+        $sortBy = $request->input('sort_by', 'created_at');
         $sortOrder = $request->input('sort_order', 'desc');
-        $search    = $request->input('search');
+        $search = $request->input('search');
 
         $perPage = $this->getPaginationSize($perPage);
 
         $records = $rdtEvent->invitations();
         $records->select('rdt_invitations.*')
             ->join('rdt_applicants', 'rdt_invitations.rdt_applicant_id', '=', 'rdt_applicants.id');
-
         $records->where('rdt_invitations.rdt_event_id', $rdtEvent->id);
         $records->whereNull('rdt_applicants.deleted_at');
 

--- a/app/Http/Resources/RdtInvitationResource.php
+++ b/app/Http/Resources/RdtInvitationResource.php
@@ -26,6 +26,7 @@ class RdtInvitationResource extends JsonResource
             'test_type'             => $this->test_type,
             'lab_code_sample'       => $this->lab_code_sample,
             'lab_result_type'       => $this->lab_result_type,
+            'status_on_simlab'      => $this->status_on_simlab,
             'notified_at'           => $this->notified_at,
             'notified_result_at'    => $this->notified_result_at,
             'synchronization_at'    => $this->synchronization_at,

--- a/database/migrations/2021_02_16_043716_add_field_status_on_simlab_on_table_rdt_invitations.php
+++ b/database/migrations/2021_02_16_043716_add_field_status_on_simlab_on_table_rdt_invitations.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFieldStatusOnSimlabOnTableRdtInvitations extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rdt_invitations', function (Blueprint $table) {
+            $table->string('status_on_simlab')->nullable()->after('lab_result_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rdt_invitations', function (Blueprint $table) {
+            $table->dropColumn('status_on_simlab');
+        });
+    }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32012588/108060476-80e12000-7089-11eb-80c1-63b7f748270e.png)

Link task on trello : https://trello.com/c/xMp7UHJd

Overview:
- Menambahkan field migrasi baru bernama 'status_on_simlab' di tabel invitation
- Mengupdate field tersebut pada setiap record yang sukses terkirim maupun yang gagal terkirim ( untuk memudahkan frontend mensortir peserta yang sudah terkirim atau gagal terkirim)
- Response payload sudah menyertakan status setiap peserta

Note:
- Tested

cc mas @yohang88 :smiling_face_with_three_hearts:  