### PR TITLE
fix unit test field symtoms notes can null

### DIFF
--- a/tests/Feature/RdtRegisterTest.php
+++ b/tests/Feature/RdtRegisterTest.php
@@ -53,7 +53,7 @@ class RdtRegisterTest extends TestCase
             ->assertStatus(422)
             ->assertJsonValidationErrors([
                 'g-recaptcha-response', 'nik', 'name', 'address', 'city_code', 'district_code', 'village_code', 'phone_number',
-                'gender', 'birth_date', 'occupation_type', 'symptoms', 'symptoms_notes'
+                'gender', 'birth_date', 'occupation_type', 'symptoms'
             ]);
     }
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/32012588/108981938-d63bb380-76bf-11eb-9d67-e75e86a032cf.png)

Issue : Error deployment because error unit test on update validation rules microsite :grin: 

Overview:
- Symtom_note field can be null (nullable)

Note:
-Tested on pic above :grin: 

cc : mas @yohang88 