### PR TITLE
make conditional when perpage is null to get all data

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
@@ -18,7 +18,7 @@ class RdtEventParticipantListController extends Controller
      */
     public function __invoke(Request $request, RdtEvent $rdtEvent)
     {
-        $perPage = $request->input('per_page');
+        $perPage = $request->input('per_page', 'ALL');
         $sortBy = $request->input('sort_by', 'created_at');
         $sortOrder = $request->input('sort_order', 'desc');
         $search = $request->input('search');
@@ -51,9 +51,7 @@ class RdtEventParticipantListController extends Controller
             return RdtInvitationResource::collection($records->get());
         }
 
-        $records = $perPage === null ? $records->get() : $records->paginate($perPage);
-
-        return RdtInvitationResource::collection($records);
+        return RdtInvitationResource::collection($records->paginate($perPage));
     }
 
     protected function getPaginationSize($perPage)

--- a/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
@@ -51,7 +51,7 @@ class RdtEventParticipantListController extends Controller
             return RdtInvitationResource::collection($records->get());
         }
 
-        $records = $perPage === null ? $records->paginate(count($records->get())) : $records->paginate($perPage);
+        $records = $perPage === null ? $records->get() : $records->paginate($perPage);
 
         return RdtInvitationResource::collection($records);
     }

--- a/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
+++ b/app/Http/Controllers/Rdt/RdtEventParticipantListController.php
@@ -18,7 +18,7 @@ class RdtEventParticipantListController extends Controller
      */
     public function __invoke(Request $request, RdtEvent $rdtEvent)
     {
-        $perPage = $request->input('per_page', 15);
+        $perPage = $request->input('per_page');
         $sortBy = $request->input('sort_by', 'created_at');
         $sortOrder = $request->input('sort_order', 'desc');
         $search = $request->input('search');
@@ -51,7 +51,9 @@ class RdtEventParticipantListController extends Controller
             return RdtInvitationResource::collection($records->get());
         }
 
-        return RdtInvitationResource::collection($records->paginate($perPage));
+        $records = $perPage === null ? $records->paginate(count($records->get())) : $records->paginate($perPage);
+
+        return RdtInvitationResource::collection($records);
     }
 
     protected function getPaginationSize($perPage)
@@ -61,6 +63,6 @@ class RdtEventParticipantListController extends Controller
         if (in_array($perPage, $perPageAllowed)) {
             return $perPage;
         }
-        return 15;
+        return $perPage;
     }
 }

--- a/tests/Feature/RdtEventParticipantListTest.php
+++ b/tests/Feature/RdtEventParticipantListTest.php
@@ -4,12 +4,13 @@ namespace Tests\Feature;
 
 use App\Entities\RdtEvent;
 use App\Entities\User;
+use Illuminate\Http\Response;
 use Tests\TestCase;
 
 class RdtEventParticipantListTest extends TestCase
 {
     /** @test */
-    public function can_show_event_list_participants()
+    public function can_show_event_all_list_participants_without_perpage()
     {
         // 1. Mock the data
         $rdtEvent = factory(RdtEvent::class)->create();
@@ -22,8 +23,8 @@ class RdtEventParticipantListTest extends TestCase
 
         // 3. Assertion
         $response->assertSuccessful()
-            ->assertJsonStructure(['data', 'meta'])
-            ->assertJsonFragment((['per_page' => 15]));
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJsonStructure(['data']);
     }
 
     /** @test */
@@ -44,7 +45,8 @@ class RdtEventParticipantListTest extends TestCase
 
         // 3. Assertion
         $response->assertSuccessful()
-            ->assertJsonStructure(['data', 'meta']);
+            ->assertStatus(Response::HTTP_OK)
+            ->assertJsonStructure(['data']);
     }
 
     /** @test */
@@ -66,6 +68,7 @@ class RdtEventParticipantListTest extends TestCase
         // 3. Assertion
         $response->assertSuccessful()
             ->assertJsonStructure(['data', 'meta'])
+            ->assertStatus(Response::HTTP_OK)
             ->assertJsonFragment((['per_page' => 50]));
     }
 }


### PR DESCRIPTION
Adjustment -> https://trello.com/c/a1LwZY6u/271-bug-preview-peserta-saat-integrasi-simlab

Overview:
- Dapat mendapatkan semua data jika `perPage === null`
- Normal menggunakan pagination jika `perPage` mempunyai `value`

Note:
- Tested on Postman

cc: mas @yohang88 :rocket: 