### PR TITLE
hotfix filter date not working on end date event

### DIFF
--- a/app/Http/Controllers/Rdt/RdtEventController.php
+++ b/app/Http/Controllers/Rdt/RdtEventController.php
@@ -185,10 +185,8 @@ class RdtEventController extends Controller
         $records->when(
             $request->has(['start_date', 'end_date']),
             function ($query) use ($eventDateStart, $eventDateEnd) {
-            // condition if event on 1 day
-                if ($eventDateStart == $eventDateEnd) {
-                    $eventDateEnd = $eventDateEnd->endOfDay();
-                }
+                $eventDateStart = $eventDateStart->startOfDay();
+                $eventDateEnd = $eventDateEnd->endOfDay();
 
                 $query->where(function ($query) use ($eventDateStart, $eventDateEnd) {
                     $query->whereBetween('start_at', [$eventDateStart, $eventDateEnd])


### PR DESCRIPTION
Overview:
- Hotfix minor filter date not working on end date event

Note:
- Tested on Postman

cc: mas @yohang88 @jabardigitalservice/jds-backend 

