### PR TITLE
up hotfix prod filter pikobar session id is not working properly

### DIFF
--- a/app/Http/Controllers/Rdt/RdtApplicantController.php
+++ b/app/Http/Controllers/Rdt/RdtApplicantController.php
@@ -150,6 +150,10 @@ class RdtApplicantController extends Controller
                 $query->where('city_code', $value);
             });
 
+            $records->when($key == 'session_id' && $value, function ($query) use ($value) {
+                $query->where('pikobar_session_id', $value);
+            });
+
             $records->when($key == 'registration_date_start', function ($query) use ($value) {
                 $query->whereDate('registration_at', '>=', Carbon::parse($value));
             });


### PR DESCRIPTION
Hotfix production 

Overview:
- Filter pikobar_session_id is not working

Note:
- Tested on postman

cc: mas @yohang88 @jabardigitalservice/jds-backend 